### PR TITLE
Use #lang r7rs for the Racket prelude

### DIFF
--- a/bench
+++ b/bench
@@ -330,8 +330,6 @@ vicare_exec ()
 
 racket_comp ()
 {
-    # remove import statement
-    sed -i -e 's/^(import (scheme.*)$//g' $1
     ${RACKET_RACO} make "$1"
 }
 
@@ -650,7 +648,7 @@ for system in $systems ; do
                  COMPCOMMANDS=""
                  EXECCOMMANDS=""
                  ;;
-        
+
         chez) NAME='Chez'
               COMP=chez_comp
               EXEC=chez_exec

--- a/src/Racket-prelude.scm
+++ b/src/Racket-prelude.scm
@@ -1,14 +1,4 @@
-#lang racket
-(require (only-in r5rs quote quasiquote unquote unquote-splicing))
-(define flush-output-port flush-output)
-(define current-jiffy current-inexact-milliseconds)
-(define (jiffies-per-second) 1000)
-(define current-second current-seconds)
-(define (square x) (* x x))
+#lang r7rs
+(import (scheme base) (only (racket base) version))
 (define (this-scheme-implementation-name)
   (string-append "racket-" (version)))
-(define inexact exact->inexact)
-(define exact inexact->exact)
-(define set-cdr! set-mcdr!)
-(define set-car! set-mcar!)
-(define cdr mcdr)


### PR DESCRIPTION
This changes the Racket prelude to use `#lang r7rs`, which appears to be able to run all the benchmarks without errors (except for one—mentioned below). However, there are some important caveats:
- Using `#lang r7rs` requires installing [the `r7rs` package](https://github.com/lexi-lambda/racket-r7rs), which is not distributed with Racket. If you want to try going down this route, you should probably add a note in the README as you see fit.
- Currently, `#lang r7rs` is implemented as an attempt at _strict compliance_, which means it might suffer some performance hits in a few areas. I am considering implementing a `#lang r7rs/interop` language that is a bit less strict but would improve Racket interop and would likely be speedier.
- The `nqueens.scm` test does not run, but I am pretty sure there is a syntax error that is not valid in any Scheme standard I know of: an `if` has 4 subforms.

Maybe just give it a try and see if it works to your liking? I figured I’d at least put this pull request together to show you what it would look like (since it’s so straightforward, anyway).
