### PR TITLE
Fix compilation for guile support

### DIFF
--- a/src/Guile-prelude.scm
+++ b/src/Guile-prelude.scm
@@ -14,3 +14,6 @@
 (define (this-scheme-implementation-name) (string-append "guile-" (version)))
 (read-enable 'r7rs-symbols)
 (print-enable 'r7rs-symbols)
+(use-modules (rnrs bytevectors)
+	     (rnrs base)
+	     (srfi srfi-9))

--- a/src/gcbench.scm
+++ b/src/gcbench.scm
@@ -81,11 +81,8 @@
       (i     node.i     node.i-set!)
       (j     node.j     node.j-set!))
 
-    (define (make-empty-node) (make-node-raw 0 0 0 0))
-
-    (define (make-node l r) (make-node-raw l r 0 0))
-
-    (let ()
+    (let ((make-empty-node (lambda () (make-node-raw 0 0 0 0)))
+	  (make-node (lambda (l r) (make-node-raw l r 0 0))))
 
       ;;  Build tree top down, assigning to older objects.
       (define (Populate iDepth thisNode)


### PR DESCRIPTION
- src/Guile-prelude.scm: import modules for missing functions
- src/gcbench.scm: use let instead of define in expression area
- src/nqueens.scm: use begin for multiline section of if

Some simple fixes for guile support. For the benchmark changes, I'm not
certain they're right for all scheme's, but I was surprised they worked
in others.

Signed-off-by: Jeff Mickey j@codemac.net
