### PR TITLE
Change Chez and Petite preludes to add support for all benchmarks.

### DIFF
--- a/src/Chez-prelude.scm
+++ b/src/Chez-prelude.scm
@@ -1,1 +1,54 @@
-(import (chezscheme))
+(import
+  (only (chezscheme)
+    current-time
+    machine-type
+    scheme-version-number
+    time-nanosecond
+    time-second)
+  (except
+    (rename (rnrs) (define-record-type r6rs:define-record-type))
+    bitwise-and
+    bitwise-not
+    div
+    mod
+    partition)
+  (rnrs mutable-pairs)
+  (rnrs mutable-strings)
+  (rnrs r5rs))
+
+(define-syntax define-record-type
+  ;; Simplistic R7RS to R6RS define-record-type transformation.
+  (syntax-rules ()
+    ((define-record-type name
+      (make-name param ...)
+      name?
+      (field-name field-ref field-set!)
+      ...)
+     (r6rs:define-record-type (name make-name name?)
+       (protocol
+         (lambda (new)
+           (lambda (param ...)
+             (new param ...))))
+       (fields
+         (mutable field-name field-ref field-set!)
+         ...)))))
+
+(define (exact-integer? z)
+  (and (exact? z) (integer? z)))
+
+ (define read-line
+   get-line)
+
+(define (square x)
+  (* x x))
+
+(define write-string
+  (case-lambda
+    ((string)
+      (put-string (current-output-port) string))
+    ((string port)
+      (put-string port string))
+    ((string port start)
+      (put-string port string start))
+    ((string port start end)
+      (put-string port string start (fx+ (fx- end start) 1)))))

--- a/src/Petite-prelude.scm
+++ b/src/Petite-prelude.scm
@@ -1,1 +1,54 @@
-(import (chezscheme))
+(import
+  (only (chezscheme)
+    current-time
+    machine-type
+    scheme-version-number
+    time-nanosecond
+    time-second)
+  (except
+    (rename (rnrs) (define-record-type r6rs:define-record-type))
+    bitwise-and
+    bitwise-not
+    div
+    mod
+    partition)
+  (rnrs mutable-pairs)
+  (rnrs mutable-strings)
+  (rnrs r5rs))
+
+(define-syntax define-record-type
+  ;; Simplistic R7RS to R6RS define-record-type transformation.
+  (syntax-rules ()
+    ((define-record-type name
+      (make-name param ...)
+      name?
+      (field-name field-ref field-set!)
+      ...)
+     (r6rs:define-record-type (name make-name name?)
+       (protocol
+         (lambda (new)
+           (lambda (param ...)
+             (new param ...))))
+       (fields
+         (mutable field-name field-ref field-set!)
+         ...)))))
+
+(define (exact-integer? z)
+  (and (exact? z) (integer? z)))
+
+ (define read-line
+   get-line)
+
+(define (square x)
+  (* x x))
+
+(define write-string
+  (case-lambda
+    ((string)
+      (put-string (current-output-port) string))
+    ((string port)
+      (put-string port string))
+    ((string port start)
+      (put-string port string start))
+    ((string port start end)
+      (put-string port string start (fx+ (fx- end start) 1)))))


### PR DESCRIPTION
Chez (and Petite) were failing many benchmarks because imported identifiers were being redefined. That's not allowed in R6RS; see [7.1](http://www.r6rs.org/final/html/r6rs/r6rs-Z-H-10.html#node_chap_7):

> An identifier can be imported with the same local name from two or more libraries or for two levels from the same library only if the binding exported by each library is the same (i.e., the binding is defined in one library, and it arrives through the imports only by exporting and re-exporting). Otherwise, no identifier can be imported multiple times, defined multiple times, or both defined and imported. No identifiers are visible within a library except for those explicitly imported into the library or defined within the library.

R7RS has the same restriction; see 5.2:

> In a program or library declaration, it is an error to import the same identifier more than once with different bindings, or to redefine or mutate an imported binding with a definition or with set!, or to refer to an identifier before it is imported.

I initially changed the benchmarks to use local names. That would have helped any R6RS-based Scheme—but I ended up thinking that was too big a change, and took this more conservative approach instead. See what you think.
