### PR TITLE
Add 32bit/64bit and singlethreaded/multithreaded to Chez/Petite implementation name.

### DIFF
--- a/src/Chez-postlude.scm
+++ b/src/Chez-postlude.scm
@@ -1,11 +1,11 @@
 (define (this-scheme-implementation-name)
   (let* ((machine-type-name (symbol->string (machine-type)))
          (threads (if (char=? (string-ref machine-type-name 0) #\t)
-                     'multithreaded
-                     'singlethreaded))
-         (bits (if (char=? (string-ref machine-type-name (if (eq? threads 'multithreaded) 2 1)) #\6)
-                   '64bit
-                   '32bit)))
+                     "multithreaded"
+                     "singlethreaded"))
+         (bits (if (char=? (string-ref machine-type-name (if (string=? threads "multithreaded") 2 1)) #\6)
+                   "64bit"
+                   "32bit")))
     (string-append "chez-" (call-with-values scheme-version-number
                              (lambda (a b c)
                                (string-append (number->string a)
@@ -13,8 +13,8 @@
                                               (number->string b)
                                               "."
                                               (number->string c))))
-                            "-" (symbol->string bits)
-                            "-" (symbol->string threads))))
+                            "-" bits
+                            "-" threads)))
 (define (current-second)
   (time-second (current-time)))
 (define (current-jiffy)

--- a/src/Chez-postlude.scm
+++ b/src/Chez-postlude.scm
@@ -1,11 +1,11 @@
 (define (this-scheme-implementation-name)
   (let* ((machine-type-name (symbol->string (machine-type)))
          (threads (if (char=? (string-ref machine-type-name 0) #\t)
-                     "multithreaded"
-                     "singlethreaded"))
-         (bits (if (char=? (string-ref machine-type-name (if (string=? threads "multithreaded") 2 1)) #\6)
-                   "64bit"
-                   "32bit")))
+                     "m"
+                     "s"))
+         (bits (if (char=? (string-ref machine-type-name (if (string=? threads "m") 2 1)) #\6)
+                   "64"
+                   "32")))
     (string-append "chez-" (call-with-values scheme-version-number
                              (lambda (a b c)
                                (string-append (number->string a)
@@ -13,8 +13,7 @@
                                               (number->string b)
                                               "."
                                               (number->string c))))
-                            "-" bits
-                            "-" threads)))
+                            "-" threads bits)))
 (define (current-second)
   (time-second (current-time)))
 (define (current-jiffy)

--- a/src/Chez-postlude.scm
+++ b/src/Chez-postlude.scm
@@ -1,11 +1,20 @@
 (define (this-scheme-implementation-name)
-  (string-append "chez-" (call-with-values scheme-version-number
-                           (lambda (a b c)
-                             (string-append (number->string a)
-                                            "."
-                                            (number->string b)
-                                            "."
-                                            (number->string c))))))
+  (let* ((machine-type-name (symbol->string (machine-type)))
+         (threads (if (char=? (string-ref machine-type-name 0) #\t)
+                     'multithreaded
+                     'singlethreaded))
+         (bits (if (char=? (string-ref machine-type-name (if (eq? threads 'multithreaded) 2 1)) #\6)
+                   '64bit
+                   '32bit)))
+    (string-append "chez-" (call-with-values scheme-version-number
+                             (lambda (a b c)
+                               (string-append (number->string a)
+                                              "."
+                                              (number->string b)
+                                              "."
+                                              (number->string c))))
+                            "-" (symbol->string bits)
+                            "-" (symbol->string threads))))
 (define (current-second)
   (time-second (current-time)))
 (define (current-jiffy)

--- a/src/Petite-postlude.scm
+++ b/src/Petite-postlude.scm
@@ -1,11 +1,20 @@
 (define (this-scheme-implementation-name)
-  (string-append "petite-" (call-with-values scheme-version-number
-                           (lambda (a b c)
-                             (string-append (number->string a)
-                                            "."
-                                            (number->string b)
-                                            "."
-                                            (number->string c))))))
+  (let* ((machine-type-name (symbol->string (machine-type)))
+         (threads (if (char=? (string-ref machine-type-name 0) #\t)
+                     'multithreaded
+                     'singlethreaded))
+         (bits (if (char=? (string-ref machine-type-name (if (eq? threads 'multithreaded) 2 1)) #\6)
+                   '64bit
+                   '32bit)))
+    (string-append "chez-" (call-with-values scheme-version-number
+                             (lambda (a b c)
+                               (string-append (number->string a)
+                                              "."
+                                              (number->string b)
+                                              "."
+                                              (number->string c))))
+                            "-" (symbol->string bits)
+                            "-" (symbol->string threads))))
 (define (current-second)
   (time-second (current-time)))
 (define (current-jiffy)

--- a/src/Petite-postlude.scm
+++ b/src/Petite-postlude.scm
@@ -1,11 +1,11 @@
 (define (this-scheme-implementation-name)
   (let* ((machine-type-name (symbol->string (machine-type)))
          (threads (if (char=? (string-ref machine-type-name 0) #\t)
-                     'multithreaded
-                     'singlethreaded))
-         (bits (if (char=? (string-ref machine-type-name (if (eq? threads 'multithreaded) 2 1)) #\6)
-                   '64bit
-                   '32bit)))
+                     "multithreaded"
+                     "singlethreaded"))
+         (bits (if (char=? (string-ref machine-type-name (if (string=? threads "multithreaded") 2 1)) #\6)
+                   "64bit"
+                   "32bit")))
     (string-append "chez-" (call-with-values scheme-version-number
                              (lambda (a b c)
                                (string-append (number->string a)
@@ -13,8 +13,8 @@
                                               (number->string b)
                                               "."
                                               (number->string c))))
-                            "-" (symbol->string bits)
-                            "-" (symbol->string threads))))
+                            "-" bits
+                            "-" threads)))
 (define (current-second)
   (time-second (current-time)))
 (define (current-jiffy)

--- a/src/Petite-postlude.scm
+++ b/src/Petite-postlude.scm
@@ -1,11 +1,11 @@
 (define (this-scheme-implementation-name)
   (let* ((machine-type-name (symbol->string (machine-type)))
          (threads (if (char=? (string-ref machine-type-name 0) #\t)
-                     "multithreaded"
-                     "singlethreaded"))
-         (bits (if (char=? (string-ref machine-type-name (if (string=? threads "multithreaded") 2 1)) #\6)
-                   "64bit"
-                   "32bit")))
+                     "m"
+                     "s"))
+         (bits (if (char=? (string-ref machine-type-name (if (string=? threads "m") 2 1)) #\6)
+                   "64"
+                   "32")))
     (string-append "chez-" (call-with-values scheme-version-number
                              (lambda (a b c)
                                (string-append (number->string a)
@@ -13,8 +13,7 @@
                                               (number->string b)
                                               "."
                                               (number->string c))))
-                            "-" bits
-                            "-" threads)))
+                            "-" threads bits)))
 (define (current-second)
   (time-second (current-time)))
 (define (current-jiffy)


### PR DESCRIPTION
On almost all platforms, Chez can be built four ways:
- 32-bit single-threaded
- 32-bit multi-threaded
- 64-bit single-threaded
- 64-bit multi-threaded

Since the variant in use can have a significant impact on performance this change adds the variant to the implementation name. (Obviously at some point it might be nice to actually time all four variants, but one thing at a time.)
