### PR TITLE
Make Chez and Gambit safe by default.

### DIFF
--- a/bench
+++ b/bench
@@ -569,7 +569,7 @@ chez_exec ()
 {
     # remove import statement
     sed -i -e 's/^(import (scheme.*)$//g' $1
-    time "${CHEZ}" --optimize-level 3 --program "$1" < "$2"
+    time "${CHEZ}" --program "$1" < "$2"
 }
 
 # -----------------------------------------------------------------------------
@@ -584,7 +584,7 @@ petite_exec ()
 {
     # remove import statement
     sed -i -e 's/^(import (scheme.*)$//g' $1
-    time "${PETITE}" --optimize-level 2 --program "$1" < "$2"
+    time "${PETITE}" --program "$1" < "$2"
 }
 
 # -----------------------------------------------------------------------------

--- a/src/GambitC-prelude.scm
+++ b/src/GambitC-prelude.scm
@@ -1,7 +1,6 @@
 (declare (standard-bindings)   ;; builtin functions like + will not be redefined
 	 (extended-bindings)   ;; Gambit functions like fixnum? will not be redefined
 	 (block)               ;; user-defined functions not set! in the file will not be redefined
-	 (not safe)            ;; Do not check for errors at runtime
 	 )
 (define (current-second) (truncate (current-jiffy)))
 (define (jiffies-per-second) 1)


### PR DESCRIPTION
I think it would be ideal to benchmark both safe and unsafe code—but in the absence of multiple tests for the same implementation it seems to me that benchmarks should be safe by default.
