### PR TITLE
Fix Gerbil postlude

### DIFF
--- a/src/Gerbil-postlude.scm
+++ b/src/Gerbil-postlude.scm
@@ -1,4 +1,3 @@
-(import (gerbil/core))
+(import (only (gerbil core) gerbil-version-string))
 (define (this-scheme-implementation-name)
   (string-append "gerbil-" (gerbil-version-string)))
-


### PR DESCRIPTION
Only import gerbil-version-string; the full gerbil/core import shadows r7rs prelude symbols.