### PR TITLE
gerbil: fix postlude, apply global declaration

### DIFF
--- a/bench
+++ b/bench
@@ -724,7 +724,7 @@ gauche_exec ()
 gerbil_comp ()
 {
     sed -i -e 's/^(main)$//' $1
-    ${GERBIL} -d $(dirname "$1") -exe -static -O -o "${1%.scm}.exe" "$1"
+    ${GERBIL} -d $(dirname "$1") -exe -static -O -prelude "(declare (not safe))" -o "${1%.scm}.exe" "$1"
 }
 
 gerbil_exec ()

--- a/src/Gerbil-postlude.scm
+++ b/src/Gerbil-postlude.scm
@@ -1,3 +1,8 @@
 (import (only (gerbil core) gerbil-version-string string-split))
 (define (this-scheme-implementation-name)
-  (string-append "gerbil-" (car (string-split (gerbil-version-string) #\-))))
+  (let* ((parts (string-split (gerbil-version-string) #\-))
+         (version
+          (if (> (length parts) 1) ; it's a dev version
+            (string-append (car parts) "-" (cadr parts))
+            (car parts))))
+    (string-append "gerbil-" version)))

--- a/src/Gerbil-postlude.scm
+++ b/src/Gerbil-postlude.scm
@@ -1,3 +1,3 @@
-(import (only (gerbil core) gerbil-version-string))
+(import (only (gerbil core) gerbil-version-string string-split))
 (define (this-scheme-implementation-name)
   (string-append "gerbil-" (car (string-split (gerbil-version-string) #\-))))


### PR DESCRIPTION
- gerbil postlude needs to import `string-split` from gerbil core.
- the postlude also keeps the `-DEV` part of development versions, so that there is no confusion about development versions that haven't been released yet.
- gxc (as of https://github.com/vyzo/gerbil/commit/91660468113df7bd347f694586669863959e5881) accepts the `-prelude` option, so we apply `(declare (not safe))` globally.