### PR TITLE
Use kawa compiler

### DIFF
--- a/bench
+++ b/bench
@@ -121,8 +121,10 @@ setup ()
     GUILD=${GUILD:-"guild"}
     GUILE=${GUILE:-"guile"}
     HUSKI=${HUSKI:-"huski"}
+    JAVA=${JAVA:-"java"}
     IRONSCHEME=${IRONSCHEME:-"ironscheme"}
     KAWA=${KAWA:-"kawa"}
+    KAWAJAR=${KAWAJAR:-/usr/share/kawa/lib/kawa.jar}
     LARCENY=${LARCENY:-"larceny"}
     MIT=${MIT:-"mit-scheme"}
     MOSH=${MOSH:-"mosh-scheme"}
@@ -734,7 +736,7 @@ gerbil_exec ()
 }
 
 # -----------------------------------------------------------------------------
-# Definitions specific to Kawa
+# Definitions specific to Husk
 
 # I could not get huskc to work:
 #
@@ -759,12 +761,14 @@ husk_exec ()
 
 kawa_comp ()
 {
-    :
+    classname=$(basename -s .scm $1)
+    "${KAWA}" --r7rs --no-warn-unused -d out --main -T $classname -C $1
 }
 
 kawa_exec ()
 {
-    time "${KAWA}" -f "$1" < "$2"
+    classname=$(basename -s .scm $1)
+    time "${JAVA}" -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
 }
 
 # -----------------------------------------------------------------------------

--- a/src/Kawa-prelude.scm
+++ b/src/Kawa-prelude.scm
@@ -14,4 +14,4 @@
 ;; (define (square x) (* x x))
 ;; (define exact-integer? integer?)
 
-(define (this-scheme-implementation-name) (string-append "kawa-" (vector-ref ((scheme-implementation-version):split " ") 0)))
+(define (this-scheme-implementation-name) (string-append "kawa-" (car (string-split (scheme-implementation-version) " "))))


### PR DESCRIPTION
This allows a few more benchmarks to run, fixes erroneous results, but doesn't seem to improve speed. 

edit: Also, adding the `--full-tailcalls` option might be of interest, but it might slow down the speed further.