### PR TITLE
Improve CHICKEN coverage

### DIFF
--- a/bench
+++ b/bench
@@ -349,7 +349,7 @@ chibi_exec ()
 
 chicken_comp ()
 {
-    OPTS="-optimize-leaf-routines -block -inline -inline-global -specialize -O3 -d0" # ecraven added -O3
+    OPTS="-M -optimize-leaf-routines -block -inline -inline-global -specialize -O3 -d0" # ecraven added -O3
     ${CHICKEN_CSC} ${OPTS} $1 -o $2 # ecraven removed -extend r7rs -require-extension r7rs which is very very bad for performance
 }
 

--- a/src/Chicken-prelude.scm
+++ b/src/Chicken-prelude.scm
@@ -14,4 +14,18 @@
 (define (square x) (* x x))
 (define exact-integer? integer?)
 
+;; bv2string
+(define make-bytevector make-u8vector)
+(define bytevector-u8-set! u8vector-set!)
+
+(define (string->utf8 string)
+  (let ((u8vector (make-u8vector (string-length string))))
+    (move-memory! string u8vector)
+    u8vector))
+
+(define (utf8->string u8vector)
+  (let ((string (make-string (u8vector-length u8vector))))
+    (move-memory! u8vector string)
+    string))
+
 (define (this-scheme-implementation-name) (string-append "chicken-" (chicken-version)))

--- a/src/Chicken-prelude.scm
+++ b/src/Chicken-prelude.scm
@@ -1,4 +1,5 @@
-(use extras) ;; for read-line
+(import chicken scheme srfi-4 lolevel)
+(use (rename extras (write-string %write-string))) ;; for read-line, write-string
 (use vector-lib) ;; for vector-map
 (define flush-output-port flush-output)
 (define-syntax import
@@ -13,6 +14,10 @@
 (define exact inexact->exact)
 (define (square x) (* x x))
 (define exact-integer? integer?)
+
+;; tail
+(define (write-string string #!optional out)
+  (%write-string string #f out))
 
 ;; bv2string
 (define make-bytevector make-u8vector)

--- a/src/ChickenCSI-prelude.scm
+++ b/src/ChickenCSI-prelude.scm
@@ -14,4 +14,20 @@
 (define (square x) (* x x))
 (define exact-integer? integer?)
 
+;; bv2string
+(use srfi-4 lolevel)
+
+(define make-bytevector make-u8vector)
+(define bytevector-u8-set! u8vector-set!)
+
+(define (string->utf8 string)
+  (let ((u8vector (make-u8vector (string-length string))))
+    (move-memory! string u8vector)
+    u8vector))
+
+(define (utf8->string u8vector)
+  (let ((string (make-string (u8vector-length u8vector))))
+    (move-memory! u8vector string)
+    string))
+
 (define (this-scheme-implementation-name) (string-append "chickencsi-" (chicken-version)))


### PR DESCRIPTION
This makes `bv2string` run both compiled and interpreted and `tail` run compiled. I'm not sure whether it's OK to forcibly wrap modules around the code, in theory that should be done anyways for the compiler to do a better job (read: detecting errors).