### PR TITLE
Add support for Loko Scheme

### DIFF
--- a/Makefile.schemes
+++ b/Makefile.schemes
@@ -58,6 +58,9 @@ kawa:
 larceny:
 	./bench larceny all
 
+loko:
+	./bench loko all
+
 mit:
 	./bench mit all
 
@@ -158,4 +161,4 @@ results.Gerbil: gerbil
 
 results.SISC: sisc
 
-all: results.Bigloo results.Bones results.Chez results.Chibi results.Chicken5 results.Chicken5CSI results.Foment results.GambitC results.Gauche results.Guile results.IronScheme results.Kawa results.Larceny results.MIT results.Petite results.Picrin results.Racket results.Rhizome results.RScheme results.S9fES results.Sagittarius results.Scheme48 results.Stalin results.TinyScheme results.Ypsilon results.Cyclone results.Femtolisp results.Gerbil results.SISC # results.Vicare
+all: results.Bigloo results.Bones results.Chez results.Chibi results.Chicken5 results.Chicken5CSI results.Foment results.GambitC results.Gauche results.Guile results.IronScheme results.Kawa results.Larceny results.Loko results.MIT results.Petite results.Picrin results.Racket results.Rhizome results.RScheme results.S9fES results.Sagittarius results.Scheme48 results.Stalin results.TinyScheme results.Ypsilon results.Cyclone results.Femtolisp results.Gerbil results.SISC # results.Vicare

--- a/README.org
+++ b/README.org
@@ -21,6 +21,7 @@ Schemes that should work:
 - [[https://github.com/leppie/IronScheme][IronScheme]] (=ironscheme=)
 - [[http://www.gnu.org/software/kawa/][Kawa]] (=kawa=)
 - [[http://www.larcenists.org/][Larceny]] (=larceny=)
+- [[https://scheme.fail/][Loko]] (=loko=)
 - [[https://www.gnu.org/software/mit-scheme/][MIT/GNU]] Scheme (=mit=)
 - [[http://mosh.monaos.org][Mosh]] (=mosh=)
 - [[http://scheme.com/][Petite Chez]] (=chez=)

--- a/bench
+++ b/bench
@@ -79,7 +79,7 @@ SYNTH_BENCHMARKS="equal bv2string"
 
 ALL_BENCHMARKS="$GABRIEL_BENCHMARKS $NUM_BENCHMARKS $KVW_BENCHMARKS $IO_BENCHMARKS $OTHER_BENCHMARKS $GC_BENCHMARKS $SYNTH_BENCHMARKS"
 
-ALL_SYSTEMS="bigloo bones chez chibi chicken5 chicken5csi cyclone femtolisp foment gambitc gauche gerbil guile ironscheme kawa larceny mit petite picrin racket rhizome rscheme s9fes sagittarius scheme48 vicare ypsilon" #  chicken4 chicken4csi
+ALL_SYSTEMS="bigloo bones chez chibi chicken5 chicken5csi cyclone femtolisp foment gambitc gauche gerbil guile ironscheme kawa larceny loko mit petite picrin racket rhizome rscheme s9fes sagittarius scheme48 vicare ypsilon" #  chicken4 chicken4csi
 ################################################################
 
 NB_RUNS=1
@@ -128,6 +128,7 @@ setup ()
     KAWA=${KAWA:-"kawa"}
     KAWAJAR=${KAWAJAR:-/usr/share/kawa/lib/kawa.jar}
     LARCENY=${LARCENY:-"larceny"}
+    LOKO=${LOKO:-"loko"}
     MIT=${MIT:-"mit-scheme"}
     MOSH=${MOSH:-"mosh-scheme"}
     PETIT=${PETIT:-"../../../../PetitGit/larceny"}
@@ -179,6 +180,7 @@ Usage: bench [-r runs] <system> <benchmark>
   ironscheme       for IronScheme
   kawa             for Kawa
   larceny          for Larceny
+  loko             for Loko Scheme
   mit              for MIT/GNU Scheme
   mosh             for Mosh
   petit            for Petit Larceny
@@ -847,6 +849,18 @@ sagittarius_exec ()
 }
 
 # -----------------------------------------------------------------------------
+# Definitions specific to Loko
+
+loko_comp ()
+{
+    ${LOKO} -std=r7rs -ftarget=linux --compile $1 --output $2
+}
+
+loko_exec ()
+{
+    time "$1" < "$2"
+}
+# -----------------------------------------------------------------------------
 
 ## Arg processing...
 if [ "$#" -lt 2 ]; then
@@ -1249,6 +1263,17 @@ for system in $systems ; do
                      COMPCOMMANDS=""
                      EXECCOMMANDS=""
                      ;;
+
+        loko) NAME='Loko'
+              COMP=loko_comp
+              EXEC=loko_exec
+              COMPOPTS=""
+              EXTENSION="scm"
+              EXTENSIONCOMP="exe"
+              COMPCOMMANDS=""
+              EXECCOMMANDS=""
+              ;;
+
         *) echo "Unknown Scheme"
            exit -1
            ;;

--- a/src/Loko-postlude.scm
+++ b/src/Loko-postlude.scm
@@ -1,0 +1,2 @@
+(define (this-scheme-implementation-name)
+  (string-append "loko-" (loko-version)))

--- a/src/Loko-prelude.scm
+++ b/src/Loko-prelude.scm
@@ -1,0 +1,1 @@
+(import (only (loko) loko-version))


### PR DESCRIPTION
This adds support for Loko Scheme. It works with Loko version 0.6.0, that comes with R7RS support.