### PR TITLE
Fix build errors with gcbench and mperm benchmarks

### DIFF
--- a/src/gcbench.scm
+++ b/src/gcbench.scm
@@ -173,7 +173,7 @@
                ))))
         (PrintDiagnostics))
 
-      (main))))
+      (run-benchmark))))
 
 (define (run-benchmark)
   (let* ((count (read))

--- a/src/mperm.scm
+++ b/src/mperm.scm
@@ -168,7 +168,7 @@
               (loop (+ i 1)))))
 
         (fill-queue 0 (- k ell))
-        (run-benchmark id
+        (%run-benchmark id
                        m
                        (lambda ()
                          (fill-queue (- k ell) k)
@@ -190,7 +190,7 @@
       (begin (display "Incorrect arguments to MpermNKL-benchmark")
              (newline))))
 
-(define (run-benchmark . args)
+(define (%run-benchmark . args)
   (apply run-r7rs-benchmark args))
 
 (define (run-benchmark)


### PR DESCRIPTION
This PR fixes issues in the `gcbench` and `mperm` benchmarks that was preventing them from running on all Schemes.