### PR TITLE
Clean importation of compiler.scm

### DIFF
--- a/src/compiler.scm
+++ b/src/compiler.scm
@@ -1,4 +1,4 @@
-(import (scheme base) (scheme file) (scheme cxr) (scheme char) (scheme complex) (scheme read) (scheme write) (scheme time))
+(import (scheme base) (scheme file) (scheme cxr) (scheme char) (scheme read) (scheme write) (scheme time))
 
 ;;; Needed for R7RS.
 


### PR DESCRIPTION
The compiler doesn't need (scheme complex) for itself. So requiring it would avoid implementations not offering that library to run the test.