### PR TITLE
Adding TR7 interpreter to the set

### DIFF
--- a/Makefile.schemes
+++ b/Makefile.schemes
@@ -104,6 +104,9 @@ scheme48:
 tinyscheme:
 	./bench tinyscheme all
 
+tr7:
+	./bench tr7 all
+
 # vicare:
 # 	./bench vicare all
 
@@ -167,6 +170,8 @@ results.Scheme48: scheme48
 results.Stalin: stalin
 
 results.TinyScheme: tinyscheme
+
+results.TR7: tr7
 
 results.Vicare: vicare
 

--- a/README.org
+++ b/README.org
@@ -32,6 +32,7 @@ Schemes that should work:
 - [[https://bitbucket.org/ktakashi/sagittarius-scheme/wiki/Home][Sagittarius]] (=sagittarius=)
 - [[http://s48.org][Scheme48]] (=scheme48=)
 - [[http://t3x.org/s9fes/][Scheme 9 from Empty Space]] (=s9fes=)
+- [[https://gitlab.com/jobol/tr7][TR7, tiny R7RS interpreter] (=TR7=)
 - [[http://marcomaggi.github.io/vicare.html][Vicare]] (=vicare=)
 - [[http://www.littlewingpinball.net/mediawiki/index.php/Ypsilon][Ypsilon]] (=ypsilon=)
 This should result in a file =./results.<scheme>=.

--- a/bench
+++ b/bench
@@ -79,7 +79,7 @@ SYNTH_BENCHMARKS="equal bv2string"
 
 ALL_BENCHMARKS="$GABRIEL_BENCHMARKS $NUM_BENCHMARKS $KVW_BENCHMARKS $IO_BENCHMARKS $OTHER_BENCHMARKS $GC_BENCHMARKS $SYNTH_BENCHMARKS"
 
-ALL_SYSTEMS="bigloo bones chez chibi chicken5 chicken5csi cyclone femtolisp foment gambitc gauche gerbil guile guile3 ironscheme kawa larceny loko mit owllisp petite picrin racket rhizome rscheme s7 s9fes sagittarius scheme48 stklos vicare ypsilon" #  chicken4 chicken4csi
+ALL_SYSTEMS="bigloo bones chez chibi chicken5 chicken5csi cyclone femtolisp foment gambitc gauche gerbil guile guile3 ironscheme kawa larceny loko mit owllisp petite picrin racket rhizome rscheme s7 s9fes sagittarius scheme48 stklos tr7 vicare ypsilon" #  chicken4 chicken4csi
 ################################################################
 
 NB_RUNS=1
@@ -151,6 +151,7 @@ setup ()
     STALIN=${STALIN:-"chicken-stalin"}
     STKLOS=${STKLOS:-"stklos"}
     TINYSCHEME=${TINYSCHEME:-"tinyscheme"}
+    TR7I=${TR7I:-"tr7i"}
     VICARE=${VICARE:-"vicare"}
     YPSILON=${YPSILON:-"ypsilon"}
 }
@@ -204,6 +205,7 @@ Usage: bench [-r runs] <system> <benchmark>
   stalin           for Stalin
   stklos           for STklos
   tinyscheme       for TinyScheme
+  tr7              for TR7
   vicare           for Vicare
   ypsilon          for Ypsilon
   all              for all of the above
@@ -512,6 +514,19 @@ tinyscheme_exec ()
 {
     sed 's/^(run-benchmark)$/(with-input-from-file (car *args*) run-benchmark)/' -i "$1"
     time ( ${TINYSCHEME} -1 "$1" "$2" )
+}
+
+# -----------------------------------------------------------------------------
+# Definitions specific to TR7
+
+tr7_comp ()
+{
+    true
+}
+
+tr7_exec ()
+{
+    time ${TR7I} "$1" < "$2"
 }
 
 # -----------------------------------------------------------------------------
@@ -1114,6 +1129,16 @@ for system in $systems ; do
         tinyscheme) NAME='TinyScheme'
                     COMP=tinyscheme_comp
                     EXEC=tinyscheme_exec
+                    COMPOPTS=""
+                    EXTENSION="scm"
+                    EXTENSIONCOMP="scm"
+                    COMPCOMMANDS=""
+                    EXECCOMMANDS=""
+                    ;;
+
+        tr7) NAME='TR7'
+                    COMP=tr7_comp
+                    EXEC=tr7_exec
                     COMPOPTS=""
                     EXTENSION="scm"
                     EXTENSIONCOMP="scm"

--- a/src/TR7-prelude.scm
+++ b/src/TR7-prelude.scm
@@ -1,0 +1,1 @@
+(define (this-scheme-implementation-name) "tr7")

--- a/src/compiler.scm
+++ b/src/compiler.scm
@@ -1,4 +1,4 @@
-(import (scheme base) (scheme file) (scheme cxr) (scheme char) (scheme complex) (scheme read) (scheme write) (scheme time))
+(import (scheme base) (scheme file) (scheme cxr) (scheme char) (scheme read) (scheme write) (scheme time))
 
 ;;; Needed for R7RS.
 


### PR DESCRIPTION
Thank you a lot for your project.

I released v1.0.0 or TR7 yesterday 4th December 2022. In my opinion it a a valuable entry for your benchmark project. 

One of my friend is creating the ARCH package that will be soon available. I'm going to remove the [WIP] tag when it will be done. So no rush (as always 8D) 