### PR TITLE
run benchmarks with Gerbil v0.18 in safe mode

### DIFF
--- a/Makefile.schemes
+++ b/Makefile.schemes
@@ -11,6 +11,9 @@ sisc:
 gerbil:
 	./bench gerbil all
 
+gerbil-unsafe:
+	./bench gerbil-unsafe all
+
 femtolisp:
 	./bench femtolisp all
 
@@ -49,12 +52,6 @@ cyclone:
 
 gambitc:
 	./bench gambitc all
-
-gerbil:
-	./bench gerbil all
-
-gerbil-unsafe:
-	./bench gerbil-unsafe all
 
 gauche:
 	./bench gauche all

--- a/Makefile.schemes
+++ b/Makefile.schemes
@@ -43,12 +43,18 @@ chicken5:
 
 chicken5csi:
 	./bench chicken5csi all
-        
+
 cyclone:
 	./bench cyclone all
 
 gambitc:
 	./bench gambitc all
+
+gerbil:
+	./bench gerbil all
+
+gerbil-unsafe:
+	./bench gerbil-unsafe all
 
 gauche:
 	./bench gauche all
@@ -181,4 +187,3 @@ results.Gerbil: gerbil
 results.SISC: sisc
 
 results.Owl-Lisp: owllisp
-

--- a/bench
+++ b/bench
@@ -438,7 +438,7 @@ stalin_comp ()
     echo "(print-brackets #f) (alexpander-repl)" | cat - $1 | sponge $1
     chez-scheme -q src/alexpander.scm < $1 > $expanded
     # ${STALIN} -On -Ob -Om -Or -Ot -d -d1 -k -copt -O3 $expanded
-    echo "(load \"/home/nex/scheme/chez/stalin/stalin.scm\") (load \"/home/nex/scheme/chez/stalin/stalin.scm\") (test \"$expanded\")" | chez-scheme -q 
+    echo "(load \"/home/nex/scheme/chez/stalin/stalin.scm\") (load \"/home/nex/scheme/chez/stalin/stalin.scm\") (test \"$expanded\")" | chez-scheme -q
 }
 
 stalin_exec ()
@@ -812,12 +812,17 @@ gauche_exec ()
 gerbil_comp ()
 {
     sed -i -e 's/^(run-benchmark)$//' $1
-    ${GERBIL} -d $(dirname "$1") -exe -static -O -prelude "(declare (not safe))" -o "${1%.scm}.exe" "$1"
+    ${GERBIL} -d $(dirname "$1") -exe -O -o "${1%.scm}.exe" "$1"
+}
+
+gerbil_unsafe_comp ()
+{
+    sed -i -e 's/^(run-benchmark)$//' $1
+    ${GERBIL} -d $(dirname "$1") -exe -O -full-program-optimization -prelude "(declare (not safe))" -o "${1%.scm}.exe" "$1"
 }
 
 gerbil_exec ()
 {
-    export GERBIL_HOME=/opt/gerbil-scheme-git/
     time "$1" < "$2"
 }
 
@@ -1240,6 +1245,16 @@ for system in $systems ; do
                  COMPCOMMANDS=""
                  EXECCOMMANDS=""
                  ;;
+
+        gerbil) NAME='Gerbil'
+                COMP=gerbil_comp
+                EXEC=gerbil_exec
+                COMPOPTS=""
+                EXTENSION="scm"
+                EXTENSIONCOMP="exe"
+                COMPCOMMANDS=""
+                EXECCOMMANDS=""
+                ;;
 
         guile) NAME='Guile'
                COMP=guile_comp

--- a/bench
+++ b/bench
@@ -180,6 +180,7 @@ Usage: bench [-r runs] <system> <benchmark>
   gambitc          for GambitC Scheme
   gauche           for Gauche
   gerbil           for Gerbil Scheme
+  gerbil-unsafe    for Gerbil Scheme with unsafe optimizations enabled
   guile            for Guile Scheme
   guile3           for Guile Scheme 3
   husk             for Husk
@@ -1248,6 +1249,16 @@ for system in $systems ; do
 
         gerbil) NAME='Gerbil'
                 COMP=gerbil_comp
+                EXEC=gerbil_exec
+                COMPOPTS=""
+                EXTENSION="scm"
+                EXTENSIONCOMP="exe"
+                COMPCOMMANDS=""
+                EXECCOMMANDS=""
+                ;;
+
+        gerbil-unsafe) NAME='Gerbil/unsafe'
+                COMP=gerbil_unsafe_comp
                 EXEC=gerbil_exec
                 COMPOPTS=""
                 EXTENSION="scm"

--- a/bench
+++ b/bench
@@ -1257,7 +1257,7 @@ for system in $systems ; do
                 EXECCOMMANDS=""
                 ;;
 
-        gerbil-unsafe) NAME='Gerbil/unsafe'
+        gerbil-unsafe) NAME='Gerbil-unsafe'
                 COMP=gerbil_unsafe_comp
                 EXEC=gerbil_exec
                 COMPOPTS=""

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 export GUILE=guile3
 export GUILD=guild3
-export GERBIL_HOME=/opt/gerbil-scheme-git/
-export GXI=/opt/gerbil-scheme-git/bin/gxi
 make clean
 make all

--- a/src/Gerbil-prelude.scm
+++ b/src/Gerbil-prelude.scm
@@ -1,3 +1,2 @@
 prelude: :scheme/r7rs
-;; (declare (not safe)) ;; do not use unsafe optimizations
-(export main)
+(%#export (rename: run-benchmark main))

--- a/src/Gerbil-unsafe-postlude.scm
+++ b/src/Gerbil-unsafe-postlude.scm
@@ -1,0 +1,8 @@
+(import (only (gerbil core) gerbil-version-string string-split))
+(define (this-scheme-implementation-name)
+  (let* ((parts (string-split (gerbil-version-string) #\-))
+         (version
+          (if (> (length parts) 1) ; it's a dev version
+            (string-append (car parts) "-" (cadr parts))
+            (car parts))))
+    (string-append "gerbil-" version)))

--- a/src/Gerbil-unsafe-prelude.scm
+++ b/src/Gerbil-unsafe-prelude.scm
@@ -1,0 +1,2 @@
+prelude: :scheme/r7rs
+(%#export (rename: run-benchmark main))


### PR DESCRIPTION
This adds back support for Gerbil, compiled in safe mode to satisfy people who think that it goes too fast when it is `(declare (not safe))`.