### PR TITLE
Disable colon for keywords in STklos

### DIFF
--- a/src/STklos-prelude.scm
+++ b/src/STklos-prelude.scm
@@ -3,5 +3,10 @@
     ((import foo bar ...)
      #t)))
 
+;; By default STklos will recognize '|: as a keyword, not the symbol |:|.
+;; so we disable keywords here (since they're not standard and not used in
+;; the benchmarks anyway).
+(keyword-colon-position 'none)
+
 (define (this-scheme-implementation-name)
   (string-append "stklos-" (version)))


### PR DESCRIPTION
By default STklos will recognize `'|:` as a keyword, not the symbol `|:|`. so we disable keywords (since they're not standard and not used in the benchmarks anyway).

This makes STklos finish the 'dynamic' benchmark.