### PR TITLE
Adjust guile and kawa parameters to better match production

### DIFF
--- a/bench
+++ b/bench
@@ -831,7 +831,7 @@ kawa_comp ()
 kawa_exec ()
 {
     classname=$(basename -s .scm $1)
-    # -XX:CompileThreshold=5 causes JIT-compilation functions after 5 calls, otherwise it takes 1000 or 10000 invocations before it gets compiled.  
+    # -XX:CompileThreshold=5 causes JIT-compilation functions after 5 calls, otherwise it takes 1000 or 10000 invocations before it gets compiled.
     time "${JAVA}" -XX:CompileThreshold=5 -XX:MaxInlineSize=9999 -XX:FreqInlineSize=9999 -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
 }
 

--- a/bench
+++ b/bench
@@ -831,9 +831,8 @@ kawa_comp ()
 kawa_exec ()
 {
     classname=$(basename -s .scm $1)
-    # -Xcomp forces JIT-compilation of all functions on  call, otherwise it takes 1000 or 10000 invocations before it gets compiled
+    # -XX:CompileThreshold=5 causes JIT-compilation functions after 5 calls, otherwise it takes 1000 or 10000 invocations before it gets compiled.  
     time "${JAVA}" -XX:CompileThreshold=5 -XX:MaxInlineSize=9999 -XX:FreqInlineSize=9999 -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
-    # time "${JAVA}" -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
 }
 
 # -----------------------------------------------------------------------------

--- a/bench
+++ b/bench
@@ -724,7 +724,9 @@ guile_comp ()
 
 guile_exec ()
 {
-    time ${GUILE} "$1" < "$2"
+    # an increased initial heap size is a better match for production
+    # because that avoids the initial heap size increments
+    time GC_INITIAL_HEAP_SIZE=100000000 ${GUILE} "$1" < "$2"
 }
 
 # -----------------------------------------------------------------------------
@@ -829,7 +831,9 @@ kawa_comp ()
 kawa_exec ()
 {
     classname=$(basename -s .scm $1)
-    time "${JAVA}" -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
+    # -Xcomp forces JIT-compilation of all functions on  call, otherwise it takes 1000 or 10000 invocations before it gets compiled
+    time "${JAVA}" -XX:CompileThreshold=5 -XX:MaxInlineSize=9999 -XX:FreqInlineSize=9999 -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
+    # time "${JAVA}" -cp $KAWAJAR:$(dirname $0)/out $classname < "$2"
 }
 
 # -----------------------------------------------------------------------------

--- a/src/Guile-prelude.scm
+++ b/src/Guile-prelude.scm
@@ -13,6 +13,7 @@
 (define (square x) (* x x))
 (define (write-string str out) (display str out)) ; sufficient for tail.scm
 (define (this-scheme-implementation-name) (string-append "guile-" (version)))
+(define arithmetic-shift ash)
 (read-enable 'r7rs-symbols)
 (print-enable 'r7rs-symbols)
 (use-modules (rnrs bytevectors)

--- a/src/Guile3-prelude.scm
+++ b/src/Guile3-prelude.scm
@@ -13,6 +13,7 @@
 (define (square x) (* x x))
 (define (write-string str out) (display str out)) ; sufficient for tail.scm
 (define (this-scheme-implementation-name) (string-append "guile3-" (version)))
+(define arithmetic-shift ash)
 (read-enable 'r7rs-symbols)
 (print-enable 'r7rs-symbols)
 (use-modules (rnrs bytevectors)


### PR DESCRIPTION
This reduces the runtime for kawa by over 20%.

<img width="1920" height="1920" alt="r7rs-plot" src="https://github.com/user-attachments/assets/697ab535-7712-46ac-a5e3-a35e4ce2c50f" />
