### PR TITLE
Add Hawk benchmark harness support

### DIFF
--- a/Makefile.schemes
+++ b/Makefile.schemes
@@ -1,4 +1,4 @@
-all: results.Bigloo results.Bones results.Chez results.Chibi results.Chicken results.Cyclone results.Femtolisp results.GambitC results.Gauche results.Gerbil results.Guile results.IronScheme results.Kawa results.Larceny results.Loko results.MIT results.Mosh results.Picrin results.Racket results.S7 results.S9fES results.Sagittarius results.Stalin results.STklos results.TR7 results.Ypsilon
+all: results.Bigloo results.Bones results.Chez results.Chibi results.Chicken results.Cyclone results.Femtolisp results.GambitC results.Gauche results.Gerbil results.Guile results.Hawk results.IronScheme results.Kawa results.Larceny results.Loko results.MIT results.Mosh results.Picrin results.Racket results.S7 results.S9fES results.Sagittarius results.Stalin results.STklos results.TR7 results.Ypsilon
 ## not relevant?
 # results.Petite-Chez results.ChickenCSI
 ## too slow / too little memory
@@ -64,6 +64,9 @@ results.Gauche:
 
 results.Guile:
 	./bench guile all
+
+results.Hawk:
+	./bench hawk all
 
 results.IronScheme:
 	./bench ironscheme all

--- a/bench
+++ b/bench
@@ -121,6 +121,7 @@ setup ()
     GXC=${GXC:-"gxc"}
     GUILD=${GUILD:-"guild"}
     GUILE=${GUILE:-"guile"}
+    HAWK=${HAWK:-"hawk"}
     HUSKI=${HUSKI:-"huski"}
     JAVA=${JAVA:-"java"}
     IRONSCHEME=${IRONSCHEME:-"ironscheme"}
@@ -177,6 +178,7 @@ Usage: bench [-r runs] <system> <benchmark>
   gauche           for Gauche
   gerbil           for Gerbil Scheme
   guile            for Guile Scheme
+  hawk             for Hawk
   husk             for Husk
   ironscheme       for IronScheme
   kawa             for Kawa
@@ -343,6 +345,19 @@ henchman_comp ()
 henchman_exec ()
 {
     time "${HENCHMAN}" --nocontract --r7rs --program "$1" < "$2"
+}
+
+# -----------------------------------------------------------------------------
+# Definitions specific to Hawk
+
+hawk_comp ()
+{
+    :
+}
+
+hawk_exec ()
+{
+    time "${HAWK}" "$1" < "$2"
 }
 
 # -----------------------------------------------------------------------------
@@ -1138,6 +1153,13 @@ for system in $systems ; do
                EXTENSION="scm"
                EXTENSIONCOMP="scm"
                ;;
+
+        hawk) NAME='Hawk'
+              COMP=hawk_comp
+              EXEC=hawk_exec
+              EXTENSION="scm"
+              EXTENSIONCOMP="scm"
+              ;;
 
         mit) NAME='MIT'
              COMP=mit_comp

--- a/src/Hawk-postlude.scm
+++ b/src/Hawk-postlude.scm
@@ -1,0 +1,1 @@
+(define (this-scheme-implementation-name) "hawk")


### PR DESCRIPTION
Hawk is a new tracing JIT based r7rs scheme. 

Here's a PKGBUILD for arch, deb for ubuntu, and source release:

https://github.com/djwatson/hawk/releases/tag/v0.10

While it's pretty fresh and not in any distro package managers yet, it's probably interesting to merge here, since it is pretty darn fast, especially on flonum benchmarks.

https://djwatson.github.io/hawk/benchmarks/